### PR TITLE
feature/pass-options-to-restify

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const start = async (options) => {
     const version = semver.valid(versionString) ? versionString : '1.0.0';
 
     const server = restify.createServer({
-        name: options.name,
+        ...options,
         version: version,
     });
 


### PR DESCRIPTION
This PR passes all options to restify's `createServer` (needed so the parameter `maxParamLength`, which defaults to 100, can be set)